### PR TITLE
Added endpoint for listing roles with their associated accesses

### DIFF
--- a/controllers/access_roles.go
+++ b/controllers/access_roles.go
@@ -1,0 +1,52 @@
+package controllers
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/jacky-htg/inventory/libraries/api"
+	"github.com/jacky-htg/inventory/models"
+	"github.com/jacky-htg/inventory/payloads/response"
+)
+
+// RoleBasedAccess : struct for setting AccessRole Dependency Injection
+type RoleBasedAccess struct {
+	Db  *sql.DB
+	Log *log.Logger
+}
+
+// List : http handler for returning list of roles with their access
+func (ar *RoleBasedAccess) List(w http.ResponseWriter, r *http.Request) {
+	var accessRole models.AccessRole
+	tx, err := ar.Db.Begin()
+	if err != nil {
+		ar.Log.Printf("Begin tx : %+v", err)
+		api.ResponseError(w, fmt.Errorf("getting roles with access list: %v", err))
+		return
+	}
+
+	list, err := accessRole.ListRolesWithAccess(r.Context(), tx)
+	if err != nil {
+		tx.Rollback()
+		ar.Log.Printf("ERROR : %+v", err)
+		api.ResponseError(w, fmt.Errorf("getting roles with access list: %v", err))
+		return
+	}
+
+	tx.Commit()
+
+	var listResponse []*response.RoleWithAccessResponse
+	for _, role := range list {
+		var roleResponse response.RoleWithAccessResponse
+		roleResponse.Transform(&role)
+		listResponse = append(listResponse, &roleResponse)
+	}
+
+	api.ResponseOK(w, response.APIResponse{
+		StatusCode:    "REBEL-200",
+		StatusMessage: "OK",
+		Data:          listResponse,
+	}, http.StatusOK)
+}

--- a/inventory.postman_collection.json
+++ b/inventory.postman_collection.json
@@ -182,7 +182,30 @@
 								}
 							},
 							"response": []
-						}
+						},
+						{
+                            "name": "role_based_access",
+                            "request": {
+                                "method": "GET",
+                                "header": [
+                                    {
+                                        "key": "Token",
+                                        "value": "{{token}}",
+                                        "type": "text"
+                                    }
+                                ],
+                                "url": {
+                                    "raw": "{{url}}/access-roles",
+                                    "host": [
+                                        "{{url}}"
+                                    ],
+                                    "path": [
+                                        "access_roles"
+                                    ]
+                                }
+                            },
+                            "response": []
+                        }
 					],
 					"protocolProfileBehavior": {},
 					"_postman_isSubFolder": true

--- a/inventory.postman_collection.json
+++ b/inventory.postman_collection.json
@@ -200,7 +200,7 @@
                                         "{{url}}"
                                     ],
                                     "path": [
-                                        "access_roles"
+                                        "access-roles"
                                     ]
                                 }
                             },

--- a/models/access_roles .go
+++ b/models/access_roles .go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"context"
+	"database/sql"
+)
+
+// AccessRole represents the access_role entity
+type AccessRole struct {
+	ID       uint32
+	AccessID uint32
+	RoleID   uint32
+}
+
+// RoleWithAccess represents a role with its associated accesses
+type RoleWithAccess struct {
+	RoleID   uint32
+	RoleName string
+	Accesses []Access
+}
+
+const qRoleWithAccess = `
+	SELECT r.id as role_id, r.name as role_name, a.id as access_id, a.alias as access_name
+	FROM access_roles ar
+	JOIN roles r ON ar.role_id = r.id
+	JOIN access a ON ar.access_id = a.id
+`
+
+// ListRolesWithAccess fetches the list of roles and their associated accesses from the database
+func (ar *AccessRole) ListRolesWithAccess(ctx context.Context, tx *sql.Tx) ([]RoleWithAccess, error) {
+	rows, err := tx.QueryContext(ctx, qRoleWithAccess)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	roleMap := make(map[uint32]*RoleWithAccess)
+	for rows.Next() {
+		var roleID uint32
+		var roleName string
+		var accessID uint32
+		var accessName string
+
+		if err := rows.Scan(&roleID, &roleName, &accessID, &accessName); err != nil {
+			return nil, err
+		}
+
+		if role, exists := roleMap[roleID]; exists {
+			role.Accesses = append(role.Accesses, Access{ID: accessID, Name: accessName})
+		} else {
+			roleMap[roleID] = &RoleWithAccess{
+				RoleID:   roleID,
+				RoleName: roleName,
+				Accesses: []Access{{ID: accessID, Name: accessName}},
+			}
+		}
+	}
+
+	var roles []RoleWithAccess
+	for _, role := range roleMap {
+		roles = append(roles, *role)
+	}
+
+	return roles, rows.Err()
+}

--- a/payloads/response/access_role_response.go
+++ b/payloads/response/access_role_response.go
@@ -1,0 +1,37 @@
+package response
+
+import "github.com/jacky-htg/inventory/models"
+
+// AccessRoleResponse is the response payload for an access entity
+type AccessRoleResponse struct {
+	AccessID   uint32 `json:"access_id"`
+	AccessName string `json:"access_name"`
+}
+
+// RoleWithAccessResponse is the response payload for a role with its access entities
+type RoleWithAccessResponse struct {
+	ID       uint32          `json:"id"`
+	RoleID   uint32          `json:"role_id"`
+	RoleName string          `json:"role_name"`
+	Access   []AccessRoleResponse `json:"access"`
+}
+
+// Transform transforms a RoleWithAccess model to a RoleWithAccessResponse
+func (r *RoleWithAccessResponse) Transform(model *models.RoleWithAccess) {
+	r.ID = model.RoleID
+	r.RoleID = model.RoleID
+	r.RoleName = model.RoleName
+	for _, access := range model.Accesses {
+		var accessResponse AccessRoleResponse
+		accessResponse.AccessID = access.ID
+		accessResponse.AccessName = access.Name
+		r.Access = append(r.Access, accessResponse)
+	}
+}
+
+// APIResponse is the standard response format
+type APIResponse struct {
+	StatusCode    string          `json:"status_code"`
+	StatusMessage string          `json:"status_message"`
+	Data          interface{}     `json:"data"`
+}

--- a/routing/route.go
+++ b/routing/route.go
@@ -65,6 +65,11 @@ func API(db *sql.DB, log *log.Logger) http.Handler {
 		access := controllers.Access{Db: db, Log: log}
 		app.Handle(http.MethodGet, "/access", access.List)
 	}
+	// Access-roles Routing
+	{
+		accessRoles := controllers.RoleBasedAccess{Db: db, Log: log}
+		app.Handle(http.MethodGet, "/access-roles", accessRoles.List)
+	}
 
 	// Regions Routing
 	{


### PR DESCRIPTION
- Created new endpoint `/access-roles` in the routing configuration.
- Implemented `ListRolesWithAccess` method in `AccessRole` model to fetch roles and their associated accesses.
- Created `RoleBasedAccess` with `List` method to handle the `/access-roles` endpoint.
- Added response payload structures to format the response as required.

API:
`GET {{url}}/access-roles`

Response:

```JSON{
    "status_code": "REBEL-200",
    "status_message": "OK",
    "data": {
        "status_code": "REBEL-200",
        "status_message": "OK",
        "data": [
            {
                "id": 2,
                "role_id": 2,
                "role_name": "Customer Services",
                "access": [
                    {
                        "access_id": 6,
                        "access_name": "users"
                    },
                    {
                        "access_id": 12,
                        "access_name": "roles"
                    },
                    {
                        "access_id": 30,
                        "access_name": "products"
                    }
                ]
            },
            {
                "id": 1,
                "role_id": 1,
                "role_name": "superadmin",
                "access": [
                    {
                        "access_id": 1,
                        "access_name": "root"
                    }
                ]
            }
        ]
    }
}
